### PR TITLE
Add imageio to requirements

### DIFF
--- a/hw1/requirements.txt
+++ b/hw1/requirements.txt
@@ -5,6 +5,7 @@ tensorboard==2.10.0
 tensorboardX==2.5.1
 matplotlib==3.1.3
 torch==1.12.1
+imageio
 pyvirtualdisplay
 IPython
 gym-notebook-wrapper


### PR DESCRIPTION
When I tried to run your instructions, I got the following error
``` File "/home/david/.local/lib/python3.8/site-packages/gym/envs/mujoco/mujoco_rendering.py", line 7, in <module>
    import imageio
ModuleNotFoundError: No module named 'imageio'
```
I fixed it by adding `imageio` to the requirements and it worked. I don't know why it's pulled in as a dependency by default. 